### PR TITLE
Support property assignment: x.y = foo()

### DIFF
--- a/doc/pattern.md
+++ b/doc/pattern.md
@@ -51,6 +51,15 @@
   baz({key: _, ...}) # Has `key` and possibly has other keys.
   ```
 
+### Property assignments
+
+- Find assignment to a property `name`:
+
+  ```
+  _.name = _               # Any receiver, any rhs.
+  _.foo.bar.name = baz()   # You can specify patterns to receiver and rhs.
+  ```
+
 ### JSX elements
 
 - Find any `div`:

--- a/src/pattern/node.ts
+++ b/src/pattern/node.ts
@@ -9,3 +9,4 @@ export { Not } from './node/not';
 export { StringLiteral } from './node/stringLiteral';
 export { Term } from './node/term';
 export { Wildcard } from './node/wildcard';
+export { Assignment } from "./node/assignment";

--- a/src/pattern/node/assignment.ts
+++ b/src/pattern/node/assignment.ts
@@ -1,0 +1,21 @@
+import * as ts from 'typescript';
+import { Node } from './node';
+import { Element } from "./element"
+
+// x.y = _
+export class Assignment extends Node {
+  constructor(readonly lhs: Element, readonly rhs: Node) { super(); }
+
+  match(expr: ts.Expression | undefined, typeChecker: ts.TypeChecker) {
+    if (expr === undefined) {
+      return false;
+    }
+
+    if (ts.isBinaryExpression(expr) && expr.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+      return this.lhs.match(expr.left, typeChecker) &&
+        this.rhs.match(expr.right, typeChecker);
+    }
+
+    return false;
+  }
+}

--- a/src/pattern/parser.ts
+++ b/src/pattern/parser.ts
@@ -18,7 +18,7 @@ export function parse(patterns: string[]) {
 
 const parser = P.createLanguage({
 
-  Root: L => P.alt(L.Expression, L.Jsx),
+  Root: L => P.alt(L.Assignment, L.Expression, L.Jsx),
 
   Jsx: L => P.seq(L.LT, L.NAME, L.JsxAttrs, L.GT)
     .map(r => new node.Jsx(r[1], r[2])),
@@ -74,6 +74,9 @@ const parser = P.createLanguage({
     }
     return e;
   }),
+
+  Assignment: L => P.seq(L.Element, L.EQ, L.Term).trim(P.optWhitespace)
+    .map((r) => new node.Assignment(r[0], r[2])),
 
   Atom: L => P.alt(
     L.NOT.then(L.Atom).map(f => new node.Not(f)),

--- a/test/res/find-assignment/sample.ts
+++ b/test/res/find-assignment/sample.ts
@@ -1,0 +1,10 @@
+interface Hello {
+  bar: string
+}
+
+function foo(): string {
+  return ""
+}
+
+const x: Hello = { bar: "123" }
+x.bar = foo();

--- a/test/res/find-assignment/tyscan.yml
+++ b/test/res/find-assignment/tyscan.yml
@@ -1,0 +1,13 @@
+rules:
+  - id: find-assignment
+    pattern: '_.bar = foo()'
+    message: '--'
+    tests:
+      match:
+        - hello.bar = foo()
+        - hello.world().bar = foo()
+      unmatch:
+        - hello.bar = 123;
+        - hello.bar = foo(123);
+        - hello.bar + foo()
+

--- a/test/testScan.ts
+++ b/test/testScan.ts
@@ -102,4 +102,12 @@ describe('scan', () => {
       'sample4.ts': [[[3, 1], [3, 11]]],
     },
   });
+
+    scan('find-assignment', {
+    'find-assignment': {
+      'sample.ts': [
+        [[10, 1], [10, 14]],
+      ],
+    }
+  });
 });

--- a/test/testTest.ts
+++ b/test/testTest.ts
@@ -20,4 +20,5 @@ describe('test', () => {
 
   test('negation', 2);
 
+  test('find-assignment', 5);
 });


### PR DESCRIPTION
I'd like to propose to add support for _property assignment_, like `(_: Location).href = _`.

* [x] Implementation
* [x] Add test
* [x] Add document