### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ npm install -g tyscan
 tyscan  # Should print help message
 ```
 
+### Docker images
+
+We provide [Docker images](https://hub.docker.com/r/sider/tyscan) for TyScan.
+
+```sh
+$ docker pull sider/tyscan
+$ docker run -it --rm -v `pwd`:/work sider/tyscan
+```
+
+You can pick a tag for the version you want to use or try with `latest` (the default.)
+(You can try with `master` tag with the latest version on `master` branch!)
+
 ## Documentation
 
 - [Sample configuration and its description](doc/config.md)


### PR DESCRIPTION
I think we should wait to merge this until we have a released version on Docker Hub.

`v0.2.1` tag contains a Dockerfile which installs TyScan 0.1.4... 😿 