### PR TITLE
Auto-install peer deps in Dockerfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,3 +18,5 @@ jobs:
       - store_artifacts:
           path: coverage
           prefix: coverage
+      - setup_remote_docker
+      - run: npm run docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM  node:8.15-alpine
-
+FROM node:8.15-alpine
 
 # Setup environment
 RUN apk update && \
@@ -8,14 +7,14 @@ RUN apk update && \
     apk del .build-deps && \
     apk add --no-cache git
 
-# Install typescript
-RUN npm install -g typescript@3.5.2
-
 # Install tyscan from source
 RUN mkdir /tyscan
 COPY . /tyscan
-RUN cd /tyscan && npm install && npm run build && npm link
+WORKDIR /tyscan
+RUN npm install && npm run build && npm link
 
+# Install peer dependencies
+RUN export npm_config_global=true && npx npm-install-peers
 
 WORKDIR /workdir
 ENTRYPOINT [ "tyscan" ]


### PR DESCRIPTION
For auto-install, this uses [npm-install-peers](https://github.com/spatie/npm-install-peers).