### PR TITLE
Remove useless text coverage report on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,6 @@ jobs:
           paths:
             - ./node_modules
       - run: npm test
-      - run: ./node_modules/.bin/nyc report --reporter=text-lcov
       - store_artifacts:
           path: coverage
           prefix: coverage


### PR DESCRIPTION
Instead, the `npm test` command generates coverage reports.

https://github.com/sider/TyScan/blob/2e60488474a58c70115b915c35278deb199d8c9b/package.json#L12