### PR TITLE
Improve Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,0 @@
-/dist
-/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.15-alpine
+FROM node:10-alpine
 
 # Setup environment
 RUN apk update && \
@@ -9,12 +9,14 @@ RUN apk update && \
 
 # Install tyscan from source
 RUN mkdir /tyscan
-COPY . /tyscan
+COPY package.json package-lock.json tsconfig.json /tyscan/
+COPY bin /tyscan/bin
+COPY src /tyscan/src
 WORKDIR /tyscan
-RUN npm install && npm run build && npm link
+RUN npm ci && npm run build && npm link
 
 # Install peer dependencies
 RUN export npm_config_global=true && npx npm-install-peers
 
-WORKDIR /workdir
+WORKDIR /work
 ENTRYPOINT [ "tyscan" ]

--- a/README.md
+++ b/README.md
@@ -11,34 +11,32 @@ TyScan is a command line tool for scanning TypeScript code.
 
 1. Install TyScan and TypeScript with `npm`:
 
-```sh
-npm install tyscan typescript --save-dev
+```shell
+$ npm install tyscan typescript --save-dev
 ```
 
 2. Check the installation:
 
-```sh
-npx tyscan  # Should print help message
+```shell
+$ npx tyscan  # Should print help message
 ```
 
-### Docker images
+### Docker
 
 We provide [Docker images](https://hub.docker.com/r/sider/tyscan) for TyScan.
 
-```sh
-$ docker pull sider/tyscan
-$ docker run -it --rm -v `pwd`:/work sider/tyscan
+```shell
+$ docker run -it --rm -v "$PWD":/work sider/tyscan
 ```
 
-You can pick a tag for the version you want to use or try with `latest` (the default.)
-(You can try with `master` tag with the latest version on `master` branch!)
+You can pick a tag for the version you want to use or try with the `latest` tag (default).
+
+Also, you can try with the `master` tag which points to the latest version on the `master` branch!
 
 ## Documentation
 
 - [Sample configuration and its description](doc/config.md)
-
 - [Pattern syntax](doc/pattern.md)
-
 - [Command line options](doc/cli.md)
 
 ## Contributing


### PR DESCRIPTION
- Update the base image for Node 10 LTS.
- Use `COPY` explicitly instead of `.dockerignore` in order to reduce the image size.
- Fix `WORKDIR` from `/workdir` to `/work` (following README).
- Change explanations about Docker images in README more readable.