### PR TITLE
Set `versioning-strategy: widen` for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
       time: "09:00"
       timezone: Asia/Tokyo
     open-pull-requests-limit: 10
+    versioning-strategy: widen
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#versioning-strategy