### PR TITLE
Fix broken `tyscan init`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,3 +24,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: npm run docker
+      - run: npm run smoke

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ typings/
 .env
 
 dist
+tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,17 @@
-FROM node:14
-
-# Install tyscan from source
-RUN mkdir /tyscan
-COPY package.json package-lock.json tsconfig.json /tyscan/
-COPY bin /tyscan/bin
-COPY src /tyscan/src
-WORKDIR /tyscan
-RUN npm ci && npm run build && npm link
-
-# Install peer dependencies
-RUN export npm_config_global=true && npx npm-install-peers
+FROM node:14 AS build
 
 WORKDIR /work
-ENTRYPOINT [ "tyscan" ]
+COPY package.json package-lock.json tsconfig.json ./
+COPY bin ./bin
+COPY src ./src
+COPY sample ./sample
+RUN npm ci && npm pack
+
+FROM node:14
+
+WORKDIR /work
+COPY --from=build /work/tyscan-*.tgz /work/tyscan.tgz
+RUN npm install -g typescript /work/tyscan.tgz && \
+    rm /work/tyscan.tgz
+
+ENTRYPOINT ["tyscan"]

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   },
   "files": [
     "bin",
-    "dist"
+    "dist",
+	"sample"
   ],
   "scripts": {
     "build": "tsc --project tsconfig.json --outDir dist",
@@ -15,6 +16,7 @@
     "test": "nyc mocha test/*.ts --no-timeouts",
     "watch": "tsc --watch --project tsconfig.json --outDir dist",
     "docker": "docker build -t sider/tyscan:dev .",
+    "smoke": "./test/smoke.sh",
     "release": "np"
   },
   "repository": {

--- a/src/cli/subcommand/initCommand.ts
+++ b/src/cli/subcommand/initCommand.ts
@@ -1,10 +1,11 @@
 import * as fs from 'fs';
+import * as path from 'path';
 import { COPYFILE_EXCL } from 'constants';
 import { Command } from './command';
 
 export class InitCommand extends Command {
 
-  private static samplePath = `${__dirname}/../../../sample/tyscan.yml`;
+  private static samplePath = path.resolve(__dirname, '../../../sample/tyscan.yml');
 
   run() {
     fs.copyFileSync(InitCommand.samplePath, 'tyscan.yml', COPYFILE_EXCL);

--- a/test/smoke.sh
+++ b/test/smoke.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euxo pipefail
+
+current_dir="$(cd "$(dirname "$0")" && pwd)"
+work_dir="${current_dir}/tmp"
+
+mkdir -p "${work_dir}"
+cd "${work_dir}"
+
+tyscan() {
+  docker run --rm -v "${work_dir}:/work" sider/tyscan:dev "$@"
+}
+
+tyscan --version
+tyscan --help
+tyscan init
+
+echo 'console.log("Hello, TyScan!");' > hello.ts
+tyscan scan
+
+rm -rf "${work_dir}"


### PR DESCRIPTION
Fix #125

This adds a new command `npm run smoke`. This command runs a smoke test via a built Docker image.