### PR TITLE
Avoid importing `constants` module

### DIFF
--- a/src/cli/subcommand/initCommand.ts
+++ b/src/cli/subcommand/initCommand.ts
@@ -1,14 +1,12 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { COPYFILE_EXCL } from 'constants';
 import { Command } from './command';
 
 export class InitCommand extends Command {
-
   private static samplePath = path.resolve(__dirname, '../../../sample/tyscan.yml');
 
   run() {
-    fs.copyFileSync(InitCommand.samplePath, 'tyscan.yml', COPYFILE_EXCL);
+    fs.copyFileSync(InitCommand.samplePath, 'tyscan.yml', fs.constants.COPYFILE_EXCL);
     return 0;
   }
 }


### PR DESCRIPTION
Use `fs.constants` instead of `import ... from 'constants'`.

- https://nodejs.org/api/fs.html#fs_fs_copyfilesync_src_dest_mode
- https://nodejs.org/api/fs.html#fs_fs_constants