### PR TITLE
Use Docker Alpine image to reduce the image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:14 AS build
+# NOTE: Use Alpine to reduce the image size.
+FROM node:14-alpine AS build
 
 WORKDIR /work
 COPY package.json package-lock.json tsconfig.json ./
@@ -7,7 +8,7 @@ COPY src ./src
 COPY sample ./sample
 RUN npm ci && npm pack
 
-FROM node:14
+FROM node:14-alpine
 
 WORKDIR /work
 COPY --from=build /work/tyscan-*.tgz /work/tyscan.tgz


### PR DESCRIPTION
I compare the diff of the image sizes: 1.01GB -> 186MB