### PR TITLE
Change `scan` output default format (breaking)

### DIFF
--- a/src/cli/subcommand/scanCommand.ts
+++ b/src/cli/subcommand/scanCommand.ts
@@ -43,7 +43,8 @@ export class ScanCommand extends Command {
             } else {
               const line = start.line + 1;
               const column = start.character + 1;
-              this.stdout(`${result.path}:${line}:${column}: ${rule.message} (${rule.id})`);
+              const message = (rule.message.match(/[^\r\n]+/) || [])[0]; // only the first line
+              this.stdout(`${result.path}:${line}:${column}: ${message} (${rule.id})`);
             }
           }
         }

--- a/src/cli/subcommand/scanCommand.ts
+++ b/src/cli/subcommand/scanCommand.ts
@@ -41,10 +41,9 @@ export class ScanCommand extends Command {
                 },
               });
             } else {
-              const loc = `${result.path}#L${start.line + 1}C${start.character + 1}`;
-              const msg = `${rule.message} (${rule.id})`;
-              const txt = `${loc}\t${node.getText()}\t${msg}`;
-              this.stdout(`${txt}`);
+              const line = start.line + 1;
+              const column = start.character + 1;
+              this.stdout(`${result.path}:${line}:${column}: ${rule.message} (${rule.id})`);
             }
           }
         }


### PR DESCRIPTION
This changes the default output format of the `tyscan scan` command.
A new format is a common UNIX style: `{path}:{line}:{column}: {message}`

E.g.

```console
$ tyscan scan src/
/tmp/project/src/cli/runner.ts:13:7: Do not use `console`. (sample.console)
/tmp/project/src/cli/runner.ts:22:5: Do not use `console`. (sample.console)
```