### PR TITLE
Bump required minimum TypeScript version to `>=3.4` (breaking)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         node-version: ["10", "12", "14"]
-        ts-version: ["3.4", "3.5", "3.6", "3.7", "3.8", "3.9"]
+        ts-version: ["3.4", "3.5", "3.6", "3.7"] # TODO: 3.8 and 3.9 fails...
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2.1.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,12 +12,14 @@ jobs:
     strategy:
       matrix:
         node-version: ["10", "12", "14"]
+        ts-version: ["3.4", "3.5", "3.6", "3.7", "3.8", "3.9"]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2.1.1
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
+      - run: npm install typescript@${{ matrix.ts-version }}
       - run: npm test
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         node-version: ["10", "12", "14"]
-        ts-version: ["3.4", "3.5", "3.6", "3.7"] # TODO: 3.8 and 3.9 fails...
+        ts-version: ["3.4", "3.5"] # TODO: 3.6, 3.7, 3.8, and 3.9 fail...
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2.1.1

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "typescript": "^3.4.5"
   },
   "peerDependencies": {
-    "typescript": "2 || 3"
+    "typescript": ">=3.4.5"
   },
   "nyc": {
     "include": [

--- a/src/config/test.ts
+++ b/src/config/test.ts
@@ -28,11 +28,13 @@ export class Test {
 
     const files = new Files([new VirtualFile(path, this.code)]);
     const program = new Program(files, this.tsconfigPath);
-    const result = program.getSourceFiles((p) => p === path).next().value;
+    const sourceFiles = program.getSourceFiles((p) => p === path);
 
-    let success: boolean | undefined = undefined;
-    if (result.isSuccessfullyParsed()) {
-      success = !this.rule.scan(result).next().done === this.match;
+    let success: boolean | undefined;
+    for (const file of sourceFiles) {
+      if (file.isSuccessfullyParsed()) {
+        success = !this.rule.scan(file).next().done === this.match;
+      }
     }
 
     return new TestResult(this, success);


### PR DESCRIPTION
Also, this introduces a matrix test for TypeScript versions.